### PR TITLE
Feature: Use az-cli for auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Azure PIM CLI
 *Azure Privileged Identity Management Command Line Interface*
 
-`az-pim-cli` eases the process of listing and activating Azure PIM roles by allowing activation via the command line. Authentication is handled with the `azure.identity` library by utilizing the `InteractiveBrowserCredential` method.
+`az-pim-cli` eases the process of listing and activating Azure PIM roles by allowing activation via the command line. Authentication is handled with the `azure.identity` library by utilizing the `AzureCLICredential` method.
 
 ## Install
 ### Install with `go install`
@@ -24,6 +24,9 @@ $ mv ./az-pim-cli /usr/local/bin
 
 ## Configuration
 In addition to supporting environment variables and command line arguments, the script also supports certain config parameters stored in a file. By default, the script will try to look for a YAML config file at `$HOME/.az-pim-cli.yaml`, but you may also override the config file to use by supplying the `--config` flag.
+
+### Prerequisites
+This tool depends on [`az-cli`](https://learn.microsoft.com/en-us/cli/azure/) for authentication. Please ensure that you've authenticated with your Azure tenant by running the command `az login`. A new browser window will open, asking you to authenticate. This should only be necessary to do once.
 
 ### YAML config file
 ```yml

--- a/cmd/activate.go
+++ b/cmd/activate.go
@@ -23,7 +23,7 @@ var activateCmd = &cobra.Command{
 	Aliases: []string{"a", "ac", "act"},
 	Short:   "Sends a request to Azure PIM to activate the given role",
 	Run: func(cmd *cobra.Command, args []string) {
-		token := pim.GetPIMAccessToken(TenantId)
+		token := pim.GetPIMAccessTokenAzureCLI()
 		subjectId := pim.GetUserInfo(token).ObjectId
 
 		eligibleRoleAssignments := pim.GetEligibleRoleAssignments(subjectId, token, resourceType)

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -14,7 +14,7 @@ var listCmd = &cobra.Command{
 	Aliases: []string{"l", "ls"},
 	Short:   "Query Azure PIM for eligible role assignments",
 	Run: func(cmd *cobra.Command, args []string) {
-		token := pim.GetPIMAccessToken(TenantId)
+		token := pim.GetPIMAccessTokenAzureCLI()
 		subjectId := pim.GetUserInfo(token).ObjectId
 
 		eligibleRoleAssignments := pim.GetEligibleRoleAssignments(subjectId, token, "azureResources")

--- a/pkg/pim/client.go
+++ b/pkg/pim/client.go
@@ -17,12 +17,8 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 )
 
-func GetPIMAccessToken(tenantId string) string {
-	credOpts := azidentity.InteractiveBrowserCredentialOptions{
-		TenantID: tenantId,
-	}
-
-	cred, err := azidentity.NewInteractiveBrowserCredential(&credOpts)
+func GetPIMAccessTokenAzureCLI() string {
+	cred, err := azidentity.NewAzureCLICredential(nil)
 	if err != nil {
 		log.Fatalln(err)
 	}


### PR DESCRIPTION
This PR changes how this tool handles authentication, by switching from InteractiveBrowserCredential to the AzureCLICredential type.

This was done mainly due to:
InteractiveBrowserCredential does not (yet) support caching of tokens, which means that every execution requires the user to sign in via a browser window. 