### PR TITLE
fix casing role on activate

### DIFF
--- a/pkg/utils/main.go
+++ b/pkg/utils/main.go
@@ -57,7 +57,7 @@ func GetRoleAssignment(name interface{}, prefix interface{}, role interface{}, e
 			}
 			if role, exists := role.(string); exists {
 				role = strings.ToLower(role)
-				if strings.Contains(eligibleRoleAssignment.RoleDefinition.DisplayName, role) {
+				if strings.Contains(strings.ToLower(eligibleRoleAssignment.RoleDefinition.DisplayName), role) {
 					return &eligibleRoleAssignment
 				}
 			}


### PR DESCRIPTION
When having a role defined in Azure with capital letters I'm not able to select to role for the activation command. This PR should fix this