### PR TITLE
feat: check for various request status types

### DIFF
--- a/pkg/pim/client.go
+++ b/pkg/pim/client.go
@@ -148,13 +148,20 @@ func ValidateRoleAssignmentRequest(scope string, roleAssignmentRequest RoleAssig
 		Payload: roleAssignmentValidationRequest,
 	}, validationResponse)
 
-	if validationResponse.Properties.Status != "Granted" {
+	if IsRoleAssignmentRequestFailed(validationResponse) {
 		log.Printf("ERROR: The role assignment validation failed with status '%s'", validationResponse.Properties.Status)
 		log.Fatalln(validationResponse)
 		return false
 	}
+	if IsRoleAssignmentRequestOK(validationResponse) {
+		return true
+	}
+	if IsRoleAssignmentRequestPending(validationResponse) {
+		log.Printf("WARNING: The role assignment request is pending with status '%s'", validationResponse.Properties.Status)
+		return true
+	}
 
-	return true
+	return false
 }
 
 func RequestRoleAssignment(subjectId string, roleAssignment *RoleAssignment, duration int, reason string, token string) *RoleAssignmentRequestResponse {

--- a/pkg/pim/models.go
+++ b/pkg/pim/models.go
@@ -81,6 +81,31 @@ type ScheduleInfo struct {
 	EndDateTime   interface{}             `json:"endDateTime"`
 }
 
+const (
+	StatusAccepted                    string = "Accepted"
+	StatusAdminApproved               string = "AdminApproved"
+	StatusAdminDenied                 string = "AdminDenied"
+	StatusCanceled                    string = "Canceled"
+	StatusDenied                      string = "Denied"
+	StatusFailed                      string = "Failed"
+	StatusFailedAsResourceIsLocked    string = "FailedAsResourceIsLocked"
+	StatusGranted                     string = "Granted"
+	StatusInvalid                     string = "Invalid"
+	StatusPendingAdminDecision        string = "PendingAdminDecision"
+	StatusPendingApproval             string = "PendingApproval"
+	StatusPendingApprovalProvisioning string = "PendingApprovalProvisioning"
+	StatusPendingEvaluation           string = "PendingEvaluation"
+	StatusPendingExternalProvisioning string = "PendingExternalProvisioning"
+	StatusPendingProvisioning         string = "PendingProvisioning"
+	StatusPendingRevocation           string = "PendingRevocation"
+	StatusPendingScheduleCreation     string = "PendingScheduleCreation"
+	StatusProvisioned                 string = "Provisioned"
+	StatusProvisioningStarted         string = "ProvisioningStarted"
+	StatusRevoked                     string = "Revoked"
+	StatusScheduleCreated             string = "ScheduleCreated"
+	StatusTimedOut                    string = "TimedOut"
+)
+
 type RoleAssignmentValidationProperties struct {
 	LinkedRoleEligibilityScheduleId string                  `json:"linkedRoleEligibilityScheduleId"`
 	TargetRoleAssignmentScheduleId  string                  `json:"targetRoleAssignmentScheduleId"`

--- a/pkg/pim/utils.go
+++ b/pkg/pim/utils.go
@@ -1,0 +1,28 @@
+/*
+Copyright © 2024 netr0m <netr0m@pm.me>
+*/
+package pim
+
+func IsRoleAssignmentRequestFailed(requestResponse *RoleAssignmentRequestResponse) bool {
+	switch requestResponse.Properties.Status {
+	case StatusAdminDenied, StatusCanceled, StatusDenied, StatusFailed, StatusFailedAsResourceIsLocked, StatusInvalid, StatusRevoked, StatusTimedOut:
+		return true
+	}
+	return false
+}
+
+func IsRoleAssignmentRequestPending(requestResponse *RoleAssignmentRequestResponse) bool {
+	switch requestResponse.Properties.Status {
+	case StatusPendingAdminDecision, StatusPendingApproval, StatusPendingApprovalProvisioning, StatusPendingEvaluation, StatusPendingExternalProvisioning, StatusPendingProvisioning, StatusPendingRevocation, StatusPendingScheduleCreation:
+		return true
+	}
+	return false
+}
+
+func IsRoleAssignmentRequestOK(requestResponse *RoleAssignmentRequestResponse) bool {
+	switch requestResponse.Properties.Status {
+	case StatusAccepted, StatusAdminApproved, StatusGranted, StatusProvisioned, StatusProvisioningStarted, StatusScheduleCreated:
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
When validating the role assignment request, it was expected that the status would be 'Granted', considering any other status to be a failure. As described in #13 , this is not always the case. This PR includes a check for various 'types' of status, including failures and various types of "Pending" statuses.

- Resolves #13  