### PR TITLE
feat: dry-run for 'activate'

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,12 +114,13 @@ Available Commands:
   group       Sends a request to Azure PIM to activate the given group
 
 Flags:
+      --dry-run         Display the resource that would be activated, without requesting the activation
   -d, --duration int    Duration in minutes that the role should be activated for (default 480)
   -h, --help            help for activate
   -n, --name string     The name of the resource to activate
   -p, --prefix string   The name prefix of the resource to activate (e.g. 'S399'). Alternative to 'name'.
       --reason string   Reason for the activation (default "config")
-  -r, --role string     Specify the role to activate, if multiple roles are found for a subscription (e.g. 'Owner' and 'Contributor')
+  -r, --role string     Specify the role to activate, if multiple roles are found for a resource (e.g. 'Owner' and 'Contributor')
 
 Global Flags:
   -c, --config string   config file (default is $HOME/.az-pim-cli.yaml)
@@ -146,11 +147,12 @@ Flags:
 
 Global Flags:
   -c, --config string   config file (default is $HOME/.az-pim-cli.yaml)
+      --dry-run         Display the resource that would be activated, without requesting the activation
   -d, --duration int    Duration in minutes that the role should be activated for (default 480)
   -n, --name string     The name of the resource to activate
   -p, --prefix string   The name prefix of the resource to activate (e.g. 'S399'). Alternative to 'name'.
       --reason string   Reason for the activation (default "config")
-  -r, --role string     Specify the role to activate, if multiple roles are found for a subscription (e.g. 'Owner' and 'Contributor')
+  -r, --role string     Specify the role to activate, if multiple roles are found for a resource (e.g. 'Owner' and 'Contributor')
 
 ```
 

--- a/cmd/activate.go
+++ b/cmd/activate.go
@@ -5,6 +5,7 @@ package cmd
 
 import (
 	"log"
+	"os"
 
 	"github.com/netr0m/az-pim-cli/pkg/pim"
 	"github.com/netr0m/az-pim-cli/pkg/utils"
@@ -16,6 +17,7 @@ var prefix string
 var roleName string
 var duration int
 var reason string
+var dryRun bool
 
 var activateCmd = &cobra.Command{
 	Use:     "activate",
@@ -35,6 +37,10 @@ var activateCmd = &cobra.Command{
 			reason,
 		)
 
+		if dryRun {
+			log.Printf("Skipping activation due to 'dry-run'.")
+			os.Exit(0)
+		}
 		requestResponse := pim.RequestRoleAssignment(subjectId, roleAssignment, duration, reason, token)
 		log.Printf("The role '%s' in '%s' is now %s", roleAssignment.Properties.ExpandedProperties.RoleDefinition.DisplayName, roleAssignment.Properties.ExpandedProperties.Scope.DisplayName, requestResponse.Properties.Status)
 	},
@@ -57,6 +63,10 @@ var activateGroupCmd = &cobra.Command{
 			reason,
 		)
 
+		if dryRun {
+			log.Printf("Skipping activation due to 'dry-run'.")
+			os.Exit(0)
+		}
 		requestResponse := pim.RequestGroupAssignment(subjectId, groupAssignment, duration, reason, pimGroupsToken)
 		log.Printf("The role '%s' for group '%s' is now %s", groupAssignment.RoleDefinition.DisplayName, groupAssignment.RoleDefinition.Resource.DisplayName, requestResponse.AssignmentState)
 	},
@@ -72,6 +82,7 @@ func init() {
 	activateCmd.PersistentFlags().StringVarP(&roleName, "role", "r", "", "Specify the role to activate, if multiple roles are found for a resource (e.g. 'Owner' and 'Contributor')")
 	activateCmd.PersistentFlags().IntVarP(&duration, "duration", "d", pim.DEFAULT_DURATION_MINUTES, "Duration in minutes that the role should be activated for")
 	activateCmd.PersistentFlags().StringVar(&reason, "reason", pim.DEFAULT_REASON, "Reason for the activation")
+	activateCmd.PersistentFlags().BoolVar(&dryRun, "dry-run", false, "Display the resource that would be activated, without requesting the activation")
 
 	activateGroupCmd.PersistentFlags().StringVarP(&pimGroupsToken, "token", "t", "", "An access token for the PIM Groups API (required). Consult the README for more information.")
 	activateGroupCmd.MarkPersistentFlagRequired("token") //nolint:errcheck


### PR DESCRIPTION
Added a flag `--dry-run` to the `activate` command, which allows checking for resource/role selection without executing the request to activate

- Resolves #21 