### PR TITLE
ci(fix): set permissions for scheduled workflow

### DIFF
--- a/.github/workflows/on-schedule.yaml
+++ b/.github/workflows/on-schedule.yaml
@@ -3,6 +3,10 @@ on:
   schedule:
     - cron: '30 2 * * 0'
 
+permissions:
+  contents: read
+  security-events: write
+
 jobs:
   snyk:
     name: Scan dependencies


### PR DESCRIPTION
# Description

`on-schedule.yaml` is missing permission `security-events: write`, which is required by both `snyk` and `semgrep`. This PR ensures that the workflow has the appropriate permissions.

- Resolves #32 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have read the [contribution guidelines](./../CONTRIBUTING.md)
- [x] My changes follow the [Styleguide](./../CONTRIBUTING.md#styleguides) of this project
- [x] I have run the [`pre-commit`](https://pre-commit.com/) hooks included in this repository
- [x] I have performed a self-review of my own code
- [N/A] I have made corresponding changes to the documentation
- [x] All GitHub Actions workflows for this branch/PR have run successfully
