### PR TITLE
ci(release-please): remove package-name to avoid prefixed releases

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,7 +1,6 @@
 {
   "packages": {
     ".": {
-      "package-name": "az-pim-cli",
       "changelog-path": "CHANGELOG.md",
       "release-type": "go",
       "bump-minor-pre-major": false,


### PR DESCRIPTION
# Description

Fix release-please config to avoid `az-pim-cli` prefix for tags

- Resolves # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] I have read the [contribution guidelines](./../CONTRIBUTING.md)
- [ ] My changes follow the [Styleguide](./../CONTRIBUTING.md#styleguides) of this project
- [ ] I have run the [`pre-commit`](https://pre-commit.com/) hooks included in this repository
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] All GitHub Actions workflows for this branch/PR have run successfully
