### PR TITLE
ci(release-please): remove package-name to avoid prefixed releases

### DIFF
--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -1,24 +1,28 @@
-name: Release a tag
+name: Goreleaser
 on:
-  push:
-    tags: ["v*"]
+  workflow_call:
+    inputs:
+      tag:
+        description: The tag to checkout to
+        required: true
+        type: string
+    secrets:
+      GITHUB_TOKEN:
+        required: true
 
 permissions:
   contents: write
 
 jobs:
-  release:
+  goreleaser:
     name: Create a release with goreleaser
     runs-on: ubuntu-latest
     steps:
-      - name: Check Actor
-        if: github.actor != 'netr0m'
-        run: exit 1
-
       - name: Checkout source code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ inputs.tag }}
 
       - name: Setup go
         uses: actions/setup-go@v5
@@ -26,7 +30,7 @@ jobs:
           go-version-file: go.mod
           check-latest: true
 
-      - name: Cache pre-commit
+      - name: Cache go modules
         uses: actions/cache@v4
         with:
           path: ~/go/pkg/mod

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -28,3 +28,14 @@ jobs:
       - name: Run release-please
         id: release
         uses: googleapis/release-please-action@v4
+
+  goreleaser:
+    name: goreleaser
+    needs: [release-please]
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    uses: ./.github/workflows/goreleaser.yaml
+    with:
+      tag: ${{ needs.release-please.outputs.tag_name }}
+    secrets: inherit
+    permissions:
+      contents: write


### PR DESCRIPTION
# Description

Run `goreleaser` on tag created by `release-please`, as `release-please` cannot trigger other workflow (i.e. `on-tag-created.yaml`) due to limitations with GH Actions

- Resolves # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] I have read the [contribution guidelines](./../CONTRIBUTING.md)
- [ ] My changes follow the [Styleguide](./../CONTRIBUTING.md#styleguides) of this project
- [ ] I have run the [`pre-commit`](https://pre-commit.com/) hooks included in this repository
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] All GitHub Actions workflows for this branch/PR have run successfully
