### PR TITLE
feat: add support for specifying 'ticket number' and 'ticket system'

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Use "az-pim-cli list [command] --help" for more information about a command.
 ```
 
 ### List eligible group assignments (Entra Groups)
-> :warn: Requires an access token with the appropriate scope. See [Token for Entra ID Groups](#token-for-entra-id-groups) for more details.
+> :warning: Requires an access token with the appropriate scope. See [Token for Entra ID Groups](#token-for-entra-id-groups) for more details.
 ```bash
 $ az-pim-cli list group --help
 Query Azure PIM for eligible group assignments
@@ -117,13 +117,15 @@ Available Commands:
   group       Sends a request to Azure PIM to activate the given group
 
 Flags:
-      --dry-run         Display the resource that would be activated, without requesting the activation
-  -d, --duration int    Duration in minutes that the role should be activated for (default 480)
-  -h, --help            help for activate
-  -n, --name string     The name of the resource to activate
-  -p, --prefix string   The name prefix of the resource to activate (e.g. 'S399'). Alternative to 'name'.
-      --reason string   Reason for the activation (default "config")
-  -r, --role string     Specify the role to activate, if multiple roles are found for a resource (e.g. 'Owner' and 'Contributor')
+      --dry-run                Display the resource that would be activated, without requesting the activation
+  -d, --duration int           Duration in minutes that the role should be activated for (default 480)
+  -h, --help                   help for activate
+  -n, --name string            The name of the resource to activate
+  -p, --prefix string          The name prefix of the resource to activate (e.g. 'S399'). Alternative to 'name'.
+      --reason string          Reason for the activation (default "config")
+  -r, --role string            Specify the role to activate, if multiple roles are found for a resource (e.g. 'Owner' and 'Contributor')
+  -T, --ticket-number string   Ticket number for the activation
+      --ticket-system string   Ticket system for the activation
 
 Global Flags:
   -c, --config string   config file (default is $HOME/.az-pim-cli.yaml)
@@ -133,7 +135,7 @@ Use "az-pim-cli activate [command] --help" for more information about a command.
 ```
 
 ### Activate a role (Entra Groups)
-> :warn: Requires an access token with the appropriate scope. See [Token for Entra ID Groups](#token-for-entra-id-groups) for more details.
+> :warning: Requires an access token with the appropriate scope. See [Token for Entra ID Groups](#token-for-entra-id-groups) for more details.
 ```bash
 $ az-pim-cli activate group --help
 Sends a request to Azure PIM to activate the given group
@@ -149,13 +151,15 @@ Flags:
   -t, --token string   An access token for the PIM Groups API (required). Consult the README for more information.
 
 Global Flags:
-  -c, --config string   config file (default is $HOME/.az-pim-cli.yaml)
-      --dry-run         Display the resource that would be activated, without requesting the activation
-  -d, --duration int    Duration in minutes that the role should be activated for (default 480)
-  -n, --name string     The name of the resource to activate
-  -p, --prefix string   The name prefix of the resource to activate (e.g. 'S399'). Alternative to 'name'.
-      --reason string   Reason for the activation (default "config")
-  -r, --role string     Specify the role to activate, if multiple roles are found for a resource (e.g. 'Owner' and 'Contributor')
+  -c, --config string          config file (default is $HOME/.az-pim-cli.yaml)
+      --dry-run                Display the resource that would be activated, without requesting the activation
+  -d, --duration int           Duration in minutes that the role should be activated for (default 480)
+  -n, --name string            The name of the resource to activate
+  -p, --prefix string          The name prefix of the resource to activate (e.g. 'S399'). Alternative to 'name'.
+      --reason string          Reason for the activation (default "config")
+  -r, --role string            Specify the role to activate, if multiple roles are found for a resource (e.g. 'Owner' and 'Contributor')
+  -T, --ticket-number string   Ticket number for the activation
+      --ticket-system string   Ticket system for the activation
 
 ```
 
@@ -172,12 +176,17 @@ $ az-pim-cli list
 
 # Activate the first matching role in a subscription with the prefix 'S100'
 $ az-pim-cli activate --prefix S100
-2024/05/31 15:05:25 Activating role 'Contributor' in subscription 'S100-Example-Subscription' with reason 'config'
+2024/05/31 15:05:25 Activating role 'Contributor' in subscription 'S100-Example-Subscription' with reason 'config' (ticket:  [])
 2024/05/31 15:05:34 The role 'Contributor' in 'S100-Example-Subscription' is now Provisioned
 
 # Activate a specific role ('Owner') in a subscription with the prefix 's100'
 $ az-pim-cli activate --prefix s100 --role owner
-2024/05/31 15:06:25 Activating role 'Owner' in subscription 'S100-Example-Subscription' with reason 'config'
+2024/05/31 15:06:25 Activating role 'Owner' in subscription 'S100-Example-Subscription' with reason 'config' (ticket:  [])
+2024/05/31 15:06:34 The role 'Owner' in 'S100-Example-Subscription' is now Provisioned
+
+# Activate a role and specify a ticket number for the activation
+$ az-pim-cli activate --name S100-Example-Subscription --role Owner --ticket-system Jira --ticket-number T-1337
+2024/05/31 15:06:25 Activating role 'Owner' in subscription 'S100-Example-Subscription' with reason 'config' (ticket: T-1337 [Jira])
 2024/05/31 15:06:34 The role 'Owner' in 'S100-Example-Subscription' is now Provisioned
 ```
 
@@ -190,7 +199,7 @@ $ az-pim-cli list groups
 
 # Activate the first matching role for the group 'my-entra-id-group'
 $ az-pim-cli activate group --name my-entra-id-group --duration 5
-2024/05/31 15:00:10 Activating role 'Owner' for group 'my-entra-id-group' with reason 'config'
+2024/05/31 15:00:10 Activating role 'Owner' for group 'my-entra-id-group' with reason 'config' (ticket:  [])
 2024/05/31 15:00:23 The role 'Owner' for group 'my-entra-id-group' is now Active
 ```
 
@@ -199,13 +208,16 @@ $ az-pim-cli activate group --name my-entra-id-group --duration 5
 - `token`: The Bearer token to use for authorization when requesting the Azure PIM Groups endpoint, i.e. listing/activating Azure PIM Groups
 
 #### YAML file
-You may define global configuration options in a YAML file.
+You may define configuration options in a YAML file.
 By default, the program will use the file ~/.az-pim-cli.yaml ($HOME/.az-pim-cli.yaml), if present. You may override this path with the command line flag `--config [PATH]`.
 
 ```bash
 $ cat ~/.az-pim-cli.yaml
 token: eyJ0[...]
-
+reason: static-reason
+ticketSystem: System
+ticketNumber: T-1337
+duration: 5
 ```
 
 #### Environment variables

--- a/cmd/activate.go
+++ b/cmd/activate.go
@@ -17,6 +17,8 @@ var prefix string
 var roleName string
 var duration int
 var reason string
+var ticketSystem string
+var ticketNumber string
 var dryRun bool
 
 var activateCmd = &cobra.Command{
@@ -31,17 +33,19 @@ var activateCmd = &cobra.Command{
 		roleAssignment := utils.GetRoleAssignment(name, prefix, roleName, eligibleRoleAssignments)
 
 		log.Printf(
-			"Activating role '%s' in subscription '%s' with reason '%s'",
+			"Activating role '%s' in subscription '%s' with reason '%s' (ticket: %s [%s])",
 			roleAssignment.Properties.ExpandedProperties.RoleDefinition.DisplayName,
 			roleAssignment.Properties.ExpandedProperties.Scope.DisplayName,
 			reason,
+			ticketNumber,
+			ticketSystem,
 		)
 
 		if dryRun {
 			log.Printf("Skipping activation due to 'dry-run'.")
 			os.Exit(0)
 		}
-		requestResponse := pim.RequestRoleAssignment(subjectId, roleAssignment, duration, reason, token)
+		requestResponse := pim.RequestRoleAssignment(subjectId, roleAssignment, duration, reason, ticketSystem, ticketNumber, token)
 		log.Printf("The role '%s' in '%s' is now %s", roleAssignment.Properties.ExpandedProperties.RoleDefinition.DisplayName, roleAssignment.Properties.ExpandedProperties.Scope.DisplayName, requestResponse.Properties.Status)
 	},
 }
@@ -57,17 +61,19 @@ var activateGroupCmd = &cobra.Command{
 		groupAssignment := utils.GetGroupAssignment(name, prefix, roleName, eligibleGroupAssignments)
 
 		log.Printf(
-			"Activating role '%s' for group '%s' with reason '%s'",
+			"Activating role '%s' for group '%s' with reason '%s' (ticket: %s [%s])",
 			groupAssignment.RoleDefinition.DisplayName,
 			groupAssignment.RoleDefinition.Resource.DisplayName,
 			reason,
+			ticketNumber,
+			ticketSystem,
 		)
 
 		if dryRun {
 			log.Printf("Skipping activation due to 'dry-run'.")
 			os.Exit(0)
 		}
-		requestResponse := pim.RequestGroupAssignment(subjectId, groupAssignment, duration, reason, pimGroupsToken)
+		requestResponse := pim.RequestGroupAssignment(subjectId, groupAssignment, duration, reason, ticketSystem, ticketNumber, pimGroupsToken)
 		log.Printf("The role '%s' for group '%s' is now %s", groupAssignment.RoleDefinition.DisplayName, groupAssignment.RoleDefinition.Resource.DisplayName, requestResponse.AssignmentState)
 	},
 }
@@ -82,6 +88,8 @@ func init() {
 	activateCmd.PersistentFlags().StringVarP(&roleName, "role", "r", "", "Specify the role to activate, if multiple roles are found for a resource (e.g. 'Owner' and 'Contributor')")
 	activateCmd.PersistentFlags().IntVarP(&duration, "duration", "d", pim.DEFAULT_DURATION_MINUTES, "Duration in minutes that the role should be activated for")
 	activateCmd.PersistentFlags().StringVar(&reason, "reason", pim.DEFAULT_REASON, "Reason for the activation")
+	activateCmd.PersistentFlags().StringVar(&ticketSystem, "ticket-system", "", "Ticket system for the activation")
+	activateCmd.PersistentFlags().StringVarP(&ticketNumber, "ticket-number", "T", "", "Ticket number for the activation")
 	activateCmd.PersistentFlags().BoolVar(&dryRun, "dry-run", false, "Display the resource that would be activated, without requesting the activation")
 
 	activateGroupCmd.PersistentFlags().StringVarP(&pimGroupsToken, "token", "t", "", "An access token for the PIM Groups API (required). Consult the README for more information.")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -70,6 +70,7 @@ func initConfig() {
 	}
 
 	bindFlags(rootCmd, vpr)
+	bindFlags(activateCmd, vpr)
 	bindFlags(listGroupCmd, vpr)
 	bindFlags(activateGroupCmd, vpr)
 }

--- a/pkg/pim/client.go
+++ b/pkg/pim/client.go
@@ -214,7 +214,7 @@ func ValidateGroupAssignmentRequest(groupAssignmentRequest GroupAssignmentReques
 	return false
 }
 
-func RequestRoleAssignment(subjectId string, roleAssignment *RoleAssignment, duration int, reason string, token string) *RoleAssignmentRequestResponse {
+func RequestRoleAssignment(subjectId string, roleAssignment *RoleAssignment, duration int, reason string, ticketSystem string, ticketNumber string, token string) *RoleAssignmentRequestResponse {
 	var params = map[string]string{
 		"api-version": AZ_PIM_API_VERSION,
 	}
@@ -233,7 +233,7 @@ func RequestRoleAssignment(subjectId string, roleAssignment *RoleAssignment, dur
 					Duration: fmt.Sprintf("PT%dM", duration),
 				},
 			},
-			TicketInfo:       &TicketInfo{TicketNumber: "", TicketSystem: "az-pim-cli"},
+			TicketInfo:       &TicketInfo{TicketNumber: ticketNumber, TicketSystem: ticketSystem},
 			IsValidationOnly: false,
 			IsActivativation: true,
 		},
@@ -260,7 +260,7 @@ func RequestRoleAssignment(subjectId string, roleAssignment *RoleAssignment, dur
 	return responseModel
 }
 
-func RequestGroupAssignment(subjectId string, groupAssignment *GroupAssignment, duration int, reason string, token string) *GroupAssignmentRequestResponse {
+func RequestGroupAssignment(subjectId string, groupAssignment *GroupAssignment, duration int, reason string, ticketSystem string, ticketNumber string, token string) *GroupAssignmentRequestResponse {
 	groupAssignmentRequest := &GroupAssignmentRequest{
 		RoleDefinitionId: groupAssignment.RoleDefinitionId,
 		ResourceId:       groupAssignment.ResourceId,
@@ -268,8 +268,8 @@ func RequestGroupAssignment(subjectId string, groupAssignment *GroupAssignment, 
 		AssignmentState:  "Active",
 		Type:             "UserAdd",
 		Reason:           reason,
-		TicketNumber:     "",
-		TicketSystem:     "az-pim-cli",
+		TicketNumber:     ticketNumber,
+		TicketSystem:     ticketSystem,
 		Schedule: &GroupAssignmentSchedule{
 			Type:          "Once",
 			StartDateTime: nil,


### PR DESCRIPTION
# Description

Adds support for specifying 'Ticket system' and 'Ticket number' with CLI flags

```sh
$ az-pim-cli activate -n SomeRole --ticket-number T-1337 --ticket-system XYZ
```

Please also include relevant motivation and context. List any dependencies that are required for this change.

- Resolves #52 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# Checklist:

- [x] I have read the [contribution guidelines](./../CONTRIBUTING.md)
- [x] My changes follow the [Styleguide](./../CONTRIBUTING.md#styleguides) of this project
- [x] I have run the [`pre-commit`](https://pre-commit.com/) hooks included in this repository
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] All GitHub Actions workflows for this branch/PR have run successfully
