### PR TITLE
feat!: use proper terms for 'azure resources' type

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Go Reference](https://pkg.go.dev/badge/github.com/netr0m/az-pim-cli.svg)](https://pkg.go.dev/github.com/netr0m/az-pim-cli)
 
 `az-pim-cli` eases the process of listing and activating Azure PIM roles by allowing activation via the command line. Authentication is handled with the `azure.identity` library by utilizing the `AzureCLICredential` method.
+It currently supports ['azure resources'](#azure-resources) and ['groups'](#groups).
 
 ## Install
 ### Install with `go install`
@@ -35,13 +36,13 @@ This tool depends on [`az-cli`](https://learn.microsoft.com/en-us/cli/azure/) fo
 ```bash
 $ az-pim-cli --help
 az-pim-cli is a utility that allows the user to list and activate eligible role assignments
-        from Azure Entra ID Privileged Identity Management (PIM) directly from the command line
+        from Azure Entra ID Privileged Identity Management (PIM) directly from the command line.
 
 Usage:
   az-pim-cli [command]
 
 Available Commands:
-  activate    Sends a request to Azure PIM to activate the given role
+  activate    Send a request to Azure PIM to activate a role assignment
   completion  Generate the autocompletion script for the specified shell
   help        Help about any command
   list        Query Azure PIM for eligible role assignments
@@ -55,35 +56,35 @@ Use "az-pim-cli [command] --help" for more information about a command.
 
 ```
 
-### List eligible role assignments (Azure resources)
+### List eligible role assignments
+
+#### Azure resources
+> List [azure resources](https://portal.azure.com/#view/Microsoft_Azure_PIMCommon/ActivationMenuBlade/~/azurerbac)
+
 ```bash
-$ az-pim-cli list --help
-Query Azure PIM for eligible role assignments
+$ az-pim-cli list resources --help
+Query Azure PIM for eligible resource assignments (azure resources)
 
 Usage:
-  az-pim-cli list [flags]
-  az-pim-cli list [command]
+  az-pim-cli list resource [flags]
 
 Aliases:
-  list, l, ls
-
-Available Commands:
-  group       Query Azure PIM for eligible group assignments
+  resource, r, res, resource, resources, sub, subs, subscriptions
 
 Flags:
-  -h, --help   help for list
+  -h, --help   help for resource
 
 Global Flags:
   -c, --config string   config file (default is $HOME/.az-pim-cli.yaml)
 
-Use "az-pim-cli list [command] --help" for more information about a command.
-
 ```
 
-### List eligible group assignments (Entra Groups)
+#### Groups
+> List [groups](https://portal.azure.com/#view/Microsoft_Azure_PIMCommon/ActivationMenuBlade/~/aadgroup)
 > :warning: Requires an access token with the appropriate scope. See [Token for Entra ID Groups](#token-for-entra-id-groups) for more details.
+
 ```bash
-$ az-pim-cli list group --help
+$ az-pim-cli list groups --help
 Query Azure PIM for eligible group assignments
 
 Usage:
@@ -101,25 +102,28 @@ Global Flags:
 
 ```
 
-### Activate a role (Azure resources)
+### Activate a role
+
+#### Azure resources
+> Activate [azure resources](https://portal.azure.com/#view/Microsoft_Azure_PIMCommon/ActivationMenuBlade/~/azurerbac)
+
 ```bash
-$ az-pim-cli activate --help
-Sends a request to Azure PIM to activate the given role
+$ az-pim-cli activate resource --help
+Sends a request to Azure PIM to activate the given resource (azure resources)
 
 Usage:
-  az-pim-cli activate [flags]
-  az-pim-cli activate [command]
+  az-pim-cli activate resource [flags]
 
 Aliases:
-  activate, a, ac, act
-
-Available Commands:
-  group       Sends a request to Azure PIM to activate the given group
+  resource, r, res, resource, resources, sub, subs, subscriptions
 
 Flags:
+  -h, --help   help for resource
+
+Global Flags:
+  -c, --config string          config file (default is $HOME/.az-pim-cli.yaml)
       --dry-run                Display the resource that would be activated, without requesting the activation
   -d, --duration int           Duration in minutes that the role should be activated for (default 480)
-  -h, --help                   help for activate
   -n, --name string            The name of the resource to activate
   -p, --prefix string          The name prefix of the resource to activate (e.g. 'S399'). Alternative to 'name'.
       --reason string          Reason for the activation (default "config")
@@ -127,15 +131,12 @@ Flags:
   -T, --ticket-number string   Ticket number for the activation
       --ticket-system string   Ticket system for the activation
 
-Global Flags:
-  -c, --config string   config file (default is $HOME/.az-pim-cli.yaml)
-
-Use "az-pim-cli activate [command] --help" for more information about a command.
-
 ```
 
-### Activate a role (Entra Groups)
+#### Groups
+> Activate [groups](https://portal.azure.com/#view/Microsoft_Azure_PIMCommon/ActivationMenuBlade/~/aadgroup)
 > :warning: Requires an access token with the appropriate scope. See [Token for Entra ID Groups](#token-for-entra-id-groups) for more details.
+
 ```bash
 $ az-pim-cli activate group --help
 Sends a request to Azure PIM to activate the given group
@@ -148,7 +149,7 @@ Aliases:
 
 Flags:
   -h, --help           help for group
-  -t, --token string   An access token for the PIM Groups API (required). Consult the README for more information.
+  -t, --token string   An access token for the PIM 'Entra Roles' and 'Groups' API (required). Consult the README for more information.
 
 Global Flags:
   -c, --config string          config file (default is $HOME/.az-pim-cli.yaml)
@@ -167,30 +168,30 @@ Global Flags:
 #### Azure resources
 ```bash
 # List eligible Azure resource role assignments
-$ az-pim-cli list
+$ az-pim-cli list resources
 == S100-Example-Subscription ==
          - Contributor
          - Owner
 == S1337-Another-Subscription ==
          - Contributor
 
-# Activate the first matching role in a subscription with the prefix 'S100'
-$ az-pim-cli activate --prefix S100
-2024/05/31 15:05:25 Activating role 'Contributor' in subscription 'S100-Example-Subscription' with reason 'config' (ticket:  [])
+# Activate the first matching role for a resource with the prefix 'S100'
+$ az-pim-cli activate resource --prefix S100
+2024/05/31 15:05:25 Activating role 'Contributor' for resource 'S100-Example-Subscription' with reason 'config' (ticket:  [])
 2024/05/31 15:05:34 The role 'Contributor' in 'S100-Example-Subscription' is now Provisioned
 
-# Activate a specific role ('Owner') in a subscription with the prefix 's100'
-$ az-pim-cli activate --prefix s100 --role owner
-2024/05/31 15:06:25 Activating role 'Owner' in subscription 'S100-Example-Subscription' with reason 'config' (ticket:  [])
+# Activate a specific role ('Owner') for a resource with the prefix 's100'
+$ az-pim-cli activate resource --prefix s100 --role owner
+2024/05/31 15:06:25 Activating role 'Owner' for resource 'S100-Example-Subscription' with reason 'config' (ticket:  [])
 2024/05/31 15:06:34 The role 'Owner' in 'S100-Example-Subscription' is now Provisioned
 
 # Activate a role and specify a ticket number for the activation
-$ az-pim-cli activate --name S100-Example-Subscription --role Owner --ticket-system Jira --ticket-number T-1337
-2024/05/31 15:06:25 Activating role 'Owner' in subscription 'S100-Example-Subscription' with reason 'config' (ticket: T-1337 [Jira])
+$ az-pim-cli activate resource --name S100-Example-Subscription --role Owner --ticket-system Jira --ticket-number T-1337
+2024/05/31 15:06:25 Activating role 'Owner' for resource 'S100-Example-Subscription' with reason 'config' (ticket: T-1337 [Jira])
 2024/05/31 15:06:34 The role 'Owner' in 'S100-Example-Subscription' is now Provisioned
 ```
 
-#### Entra groups
+#### Groups
 ```bash
 # List eligible group assignments
 $ az-pim-cli list groups

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -13,11 +13,18 @@ var listCmd = &cobra.Command{
 	Use:     "list",
 	Aliases: []string{"l", "ls"},
 	Short:   "Query Azure PIM for eligible role assignments",
+	Run:     func(cmd *cobra.Command, args []string) {},
+}
+
+var listResourceCmd = &cobra.Command{
+	Use:     "resource",
+	Aliases: []string{"r", "res", "resource", "resources", "sub", "subs", "subscriptions"},
+	Short:   "Query Azure PIM for eligible resource assignments (azure resources)",
 	Run: func(cmd *cobra.Command, args []string) {
 		token := pim.GetPIMAccessTokenAzureCLI(pim.AZ_PIM_SCOPE)
 
-		eligibleRoleAssignments := pim.GetEligibleRoleAssignments(token)
-		utils.PrintEligibleRoles(eligibleRoleAssignments)
+		eligibleResourceAssignments := pim.GetEligibleResourceAssignments(token)
+		utils.PrintEligibleResources(eligibleResourceAssignments)
 	},
 }
 
@@ -34,6 +41,7 @@ var listGroupCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(listCmd)
+	listCmd.AddCommand(listResourceCmd)
 	listCmd.AddCommand(listGroupCmd)
 
 	listGroupCmd.PersistentFlags().StringVarP(&pimGroupsToken, "token", "t", "", "An access token for the PIM Groups API (required). Consult the README for more information.")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -20,7 +20,7 @@ var rootCmd = &cobra.Command{
 	Use:   "az-pim-cli",
 	Short: "A utility to list and activate Azure AD PIM roles from the CLI",
 	Long: `az-pim-cli is a utility that allows the user to list and activate eligible role assignments
-	from Azure Entra ID Privileged Identity Management (PIM) directly from the command line`,
+	from Azure Entra ID Privileged Identity Management (PIM) directly from the command line.`,
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.

--- a/pkg/pim/models.go
+++ b/pkg/pim/models.go
@@ -24,44 +24,44 @@ type PIMRequest struct {
 	Params  map[string]string
 }
 
-type RoleExpandedProperty struct {
+type ResourceExpandedProperty struct {
 	Id          string `json:"id"`
 	DisplayName string `json:"displayName"`
 	Type        string `json:"type"`
 	Email       string `json:"email"`
 }
 
-type RoleExpandedProperties struct {
-	Principal      *RoleExpandedProperty `json:"principal"`
-	RoleDefinition *RoleExpandedProperty `json:"roleDefinition"`
-	Scope          *RoleExpandedProperty `json:"scope"`
+type ResourceExpandedProperties struct {
+	Principal      *ResourceExpandedProperty `json:"principal"`
+	RoleDefinition *ResourceExpandedProperty `json:"roleDefinition"`
+	Scope          *ResourceExpandedProperty `json:"scope"`
 }
 
-type RoleProperties struct {
-	RoleEligibilityScheduleId string                  `json:"roleEligibilityScheduleId"`
-	Scope                     string                  `json:"scope"`
-	RoleDefinitionId          string                  `json:"roleDefinitionId"`
-	PrincipalId               string                  `json:"principalId"`
-	PrincipalType             string                  `json:"principalType"`
-	Status                    string                  `json:"status"`
-	StartDateTime             string                  `json:"startDateTime"`
-	EndDateTime               string                  `json:"endDateTime"`
-	MemberType                string                  `json:"memberType"`
-	CreatedOn                 string                  `json:"createdOn"`
-	Condition                 string                  `json:"condition"`
-	ConditionVersion          string                  `json:"conditionVersion"`
-	ExpandedProperties        *RoleExpandedProperties `json:"expandedProperties"`
+type ResourceProperties struct {
+	RoleEligibilityScheduleId string                      `json:"roleEligibilityScheduleId"`
+	Scope                     string                      `json:"scope"`
+	RoleDefinitionId          string                      `json:"roleDefinitionId"`
+	PrincipalId               string                      `json:"principalId"`
+	PrincipalType             string                      `json:"principalType"`
+	Status                    string                      `json:"status"`
+	StartDateTime             string                      `json:"startDateTime"`
+	EndDateTime               string                      `json:"endDateTime"`
+	MemberType                string                      `json:"memberType"`
+	CreatedOn                 string                      `json:"createdOn"`
+	Condition                 string                      `json:"condition"`
+	ConditionVersion          string                      `json:"conditionVersion"`
+	ExpandedProperties        *ResourceExpandedProperties `json:"expandedProperties"`
 }
 
-type RoleAssignment struct {
-	Properties *RoleProperties `json:"properties"`
-	Name       string          `json:"name"`
-	Id         string          `json:"id"`
-	Type       string          `json:"type"`
+type ResourceAssignment struct {
+	Properties *ResourceProperties `json:"properties"`
+	Name       string              `json:"name"`
+	Id         string              `json:"id"`
+	Type       string              `json:"type"`
 }
 
-type RoleAssignmentResponse struct {
-	Value []RoleAssignment `json:"value"`
+type ResourceAssignmentResponse struct {
+	Value []ResourceAssignment `json:"value"`
 }
 
 type GroupAssignmentSubject struct {
@@ -143,31 +143,31 @@ const (
 	StatusTimedOut                    string = "TimedOut"
 )
 
-type RoleAssignmentValidationProperties struct {
-	LinkedRoleEligibilityScheduleId string                  `json:"linkedRoleEligibilityScheduleId"`
-	TargetRoleAssignmentScheduleId  string                  `json:"targetRoleAssignmentScheduleId"`
-	Scope                           string                  `json:"scope"`
-	RoleDefinitionId                string                  `json:"roleDefinitionId"`
-	PrincipalId                     string                  `json:"principalId"`
-	PrincipalType                   string                  `json:"principalType"`
-	RequestType                     string                  `json:"requestType"`
-	Status                          string                  `json:"status"`
-	ScheduleInfo                    *ScheduleInfo           `json:"scheduleInfo"`
-	TicketInfo                      *TicketInfo             `json:"ticketInfo"`
-	Justification                   string                  `json:"justification"`
-	RequestorId                     string                  `json:"requestorId"`
-	CreatedOn                       string                  `json:"createdOn"`
-	ExpandedProperties              *RoleExpandedProperties `json:"expandedProperties"`
+type ResourceAssignmentValidationProperties struct {
+	LinkedRoleEligibilityScheduleId string                      `json:"linkedRoleEligibilityScheduleId"`
+	TargetRoleAssignmentScheduleId  string                      `json:"targetRoleAssignmentScheduleId"`
+	Scope                           string                      `json:"scope"`
+	RoleDefinitionId                string                      `json:"roleDefinitionId"`
+	PrincipalId                     string                      `json:"principalId"`
+	PrincipalType                   string                      `json:"principalType"`
+	RequestType                     string                      `json:"requestType"`
+	Status                          string                      `json:"status"`
+	ScheduleInfo                    *ScheduleInfo               `json:"scheduleInfo"`
+	TicketInfo                      *TicketInfo                 `json:"ticketInfo"`
+	Justification                   string                      `json:"justification"`
+	RequestorId                     string                      `json:"requestorId"`
+	CreatedOn                       string                      `json:"createdOn"`
+	ExpandedProperties              *ResourceExpandedProperties `json:"expandedProperties"`
 }
 
-type RoleAssignmentRequestResponse struct {
-	Properties *RoleAssignmentValidationProperties `json:"properties"`
-	Name       string                              `json:"name"`
-	Id         string                              `json:"id"`
-	Type       string                              `json:"type"`
+type ResourceAssignmentRequestResponse struct {
+	Properties *ResourceAssignmentValidationProperties `json:"properties"`
+	Name       string                                  `json:"name"`
+	Id         string                                  `json:"id"`
+	Type       string                                  `json:"type"`
 }
 
-type RoleAssignmentRequestProperties struct {
+type ResourceAssignmentRequestProperties struct {
 	PrincipalId                     string        `json:"PrincipalId"`
 	RoleDefinitionId                string        `json:"RoleDefinitionId"`
 	RequestType                     string        `json:"RequestType"`
@@ -179,8 +179,8 @@ type RoleAssignmentRequestProperties struct {
 	IsActivativation                bool          `json:"IsActivativation"` // yes, this typo is in the API
 }
 
-type RoleAssignmentRequestRequest struct {
-	Properties RoleAssignmentRequestProperties `json:"Properties"`
+type ResourceAssignmentRequestRequest struct {
+	Properties ResourceAssignmentRequestProperties `json:"Properties"`
 }
 
 type GroupAssignmentSchedule struct {

--- a/pkg/pim/utils.go
+++ b/pkg/pim/utils.go
@@ -3,7 +3,7 @@ Copyright © 2024 netr0m <netr0m@pm.me>
 */
 package pim
 
-func IsRoleAssignmentRequestFailed(requestResponse *RoleAssignmentRequestResponse) bool {
+func IsResourceAssignmentRequestFailed(requestResponse *ResourceAssignmentRequestResponse) bool {
 	switch requestResponse.Properties.Status {
 	case StatusAdminDenied, StatusCanceled, StatusDenied, StatusFailed, StatusFailedAsResourceIsLocked, StatusInvalid, StatusRevoked, StatusTimedOut:
 		return true
@@ -19,7 +19,7 @@ func IsGroupAssignmentRequestFailed(requestResponse *GroupAssignmentRequestRespo
 	return false
 }
 
-func IsRoleAssignmentRequestPending(requestResponse *RoleAssignmentRequestResponse) bool {
+func IsResourceAssignmentRequestPending(requestResponse *ResourceAssignmentRequestResponse) bool {
 	switch requestResponse.Properties.Status {
 	case StatusPendingAdminDecision, StatusPendingApproval, StatusPendingApprovalProvisioning, StatusPendingEvaluation, StatusPendingExternalProvisioning, StatusPendingProvisioning, StatusPendingRevocation, StatusPendingScheduleCreation:
 		return true
@@ -35,7 +35,7 @@ func IsGroupAssignmentRequestPending(requestResponse *GroupAssignmentRequestResp
 	return false
 }
 
-func IsRoleAssignmentRequestOK(requestResponse *RoleAssignmentRequestResponse) bool {
+func IsResourceAssignmentRequestOK(requestResponse *ResourceAssignmentRequestResponse) bool {
 	switch requestResponse.Properties.Status {
 	case StatusAccepted, StatusAdminApproved, StatusGranted, StatusProvisioned, StatusProvisioningStarted, StatusScheduleCreated:
 		return true

--- a/pkg/utils/main.go
+++ b/pkg/utils/main.go
@@ -11,19 +11,19 @@ import (
 	"github.com/netr0m/az-pim-cli/pkg/pim"
 )
 
-func PrintEligibleRoles(roleEligibilityScheduleInstances *pim.RoleAssignmentResponse) {
-	var eligibleRoles = make(map[string][]string)
+func PrintEligibleResources(resourceAssignments *pim.ResourceAssignmentResponse) {
+	var eligibleResources = make(map[string][]string)
 
-	for _, ras := range roleEligibilityScheduleInstances.Value {
-		subscriptionName := ras.Properties.ExpandedProperties.Scope.DisplayName
+	for _, ras := range resourceAssignments.Value {
+		resourceName := ras.Properties.ExpandedProperties.Scope.DisplayName
 		roleName := ras.Properties.ExpandedProperties.RoleDefinition.DisplayName
-		if _, ok := eligibleRoles[subscriptionName]; !ok {
-			eligibleRoles[subscriptionName] = []string{}
+		if _, ok := eligibleResources[resourceName]; !ok {
+			eligibleResources[resourceName] = []string{}
 		}
-		eligibleRoles[subscriptionName] = append(eligibleRoles[subscriptionName], roleName)
+		eligibleResources[resourceName] = append(eligibleResources[resourceName], roleName)
 	}
 
-	for sub, rol := range eligibleRoles {
+	for sub, rol := range eligibleResources {
 		fmt.Printf("== %s ==\n", sub)
 		for role := range rol {
 			fmt.Printf("\t - %s\n", rol[role])
@@ -51,35 +51,35 @@ func PrintEligibleGroups(groupAssignments *pim.GroupAssignmentResponse) {
 	}
 }
 
-func GetRoleAssignment(name string, prefix string, role string, eligibleRoleAssignments *pim.RoleAssignmentResponse) *pim.RoleAssignment {
+func GetResourceAssignment(name string, prefix string, role string, eligibleResourceAssignments *pim.ResourceAssignmentResponse) *pim.ResourceAssignment {
 	name = strings.ToLower(name)
 	prefix = strings.ToLower(prefix)
 	role = strings.ToLower(role)
-	for _, eligibleRoleAssignment := range eligibleRoleAssignments.Value {
-		var match *pim.RoleAssignment = nil
-		subscriptionName := strings.ToLower(eligibleRoleAssignment.Properties.ExpandedProperties.Scope.DisplayName)
+	for _, eligibleResourceAssignment := range eligibleResourceAssignments.Value {
+		var match *pim.ResourceAssignment = nil
+		resourceName := strings.ToLower(eligibleResourceAssignment.Properties.ExpandedProperties.Scope.DisplayName)
 
 		if len(prefix) != 0 {
-			if strings.HasPrefix(subscriptionName, prefix) {
-				match = &eligibleRoleAssignment
+			if strings.HasPrefix(resourceName, prefix) {
+				match = &eligibleResourceAssignment
 			}
 		} else if len(name) != 0 {
-			if subscriptionName == name {
-				match = &eligibleRoleAssignment
+			if resourceName == name {
+				match = &eligibleResourceAssignment
 			}
 		}
 
 		if match != nil {
 			if role == "" {
-				return &eligibleRoleAssignment
+				return &eligibleResourceAssignment
 			}
-			if strings.ToLower(eligibleRoleAssignment.Properties.ExpandedProperties.RoleDefinition.DisplayName) == role {
-				return &eligibleRoleAssignment
+			if strings.ToLower(eligibleResourceAssignment.Properties.ExpandedProperties.RoleDefinition.DisplayName) == role {
+				return &eligibleResourceAssignment
 			}
 		}
 	}
 
-	log.Fatalln("Unable to find a role assignment matching the parameters.")
+	log.Fatalln("Unable to find a resource assignment matching the parameters.")
 
 	return nil
 }


### PR DESCRIPTION
# Description

Use the appropriate wording 'resource' for 'Azure resources', formerly called 'role[s]', to better represent the type of role it applies to and to facilitate for the upcoming addition of the 'Microsoft Entra Roles' role type (#54)

This is a breaking change due to changes to the CLI, where the base commands `az-pim-cli activate` and `az-pim-cli activate` no longer manages 'azure resources'. These have now been moved to `az-pim-cli activate resource [flags]` and `az-pim-cli list resource` (e.g. similarly to how `group` is handled already).

- Resolves #58
- Relates to #54 

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:

- [x] I have read the [contribution guidelines](./../CONTRIBUTING.md)
- [x] My changes follow the [Styleguide](./../CONTRIBUTING.md#styleguides) of this project
- [x] I have run the [`pre-commit`](https://pre-commit.com/) hooks included in this repository
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] All GitHub Actions workflows for this branch/PR have run successfully
