### PR TITLE
feat: add support for setting start-time

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.6.0
+  rev: v5.0.0
   hooks:
     - id: trailing-whitespace
     - id: end-of-file-fixer
@@ -11,13 +11,13 @@ repos:
       stages: [pre-commit]
 
 - repo: https://github.com/golangci/golangci-lint
-  rev: v1.61.0
+  rev: v1.64.5
   hooks:
     - id: golangci-lint
     - id: golangci-lint-full
 
 - repo: https://github.com/compilerla/conventional-pre-commit
-  rev: v3.6.0
+  rev: v4.0.0
   hooks:
     - id: conventional-pre-commit
       stages: [commit-msg]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     - id: end-of-file-fixer
     - id: check-yaml
     - id: check-added-large-files
-      stages: [commit]
+      stages: [pre-commit]
 
 - repo: https://github.com/golangci/golangci-lint
   rev: v1.61.0

--- a/README.md
+++ b/README.md
@@ -158,8 +158,11 @@ Global Flags:
   -p, --prefix string          The name prefix of the resource to activate (e.g. 'S399'). Alternative to 'name'.
       --reason string          Reason for the activation (default "config")
   -r, --role string            Specify the role to activate, if multiple roles are found for a resource (e.g. 'Owner' and 'Contributor')
+      --start-date string      Start date for the activation (as DD/MM/YYYY)
+  -s, --start-time string      Start time for the activation (as HH:MM)
   -T, --ticket-number string   Ticket number for the activation
       --ticket-system string   Ticket system for the activation
+  -v, --validate-only          Send the request to the validation endpoint of Azure PIM, without requesting the activation
 
 ```
 
@@ -191,8 +194,11 @@ Global Flags:
   -p, --prefix string          The name prefix of the resource to activate (e.g. 'S399'). Alternative to 'name'.
       --reason string          Reason for the activation (default "config")
   -r, --role string            Specify the role to activate, if multiple roles are found for a resource (e.g. 'Owner' and 'Contributor')
+      --start-date string      Start date for the activation (as DD/MM/YYYY)
+  -s, --start-time string      Start time for the activation (as HH:MM)
   -T, --ticket-number string   Ticket number for the activation
       --ticket-system string   Ticket system for the activation
+  -v, --validate-only          Send the request to the validation endpoint of Azure PIM, without requesting the activation
 
 ```
 
@@ -203,7 +209,6 @@ Global Flags:
 
 ```bash
 $ az-pim-cli activate role --help
-go run main.go activate role --help
 Sends a request to Azure PIM to activate the given Entra role
 
 Usage:
@@ -225,8 +230,11 @@ Global Flags:
   -p, --prefix string          The name prefix of the resource to activate (e.g. 'S399'). Alternative to 'name'.
       --reason string          Reason for the activation (default "config")
   -r, --role string            Specify the role to activate, if multiple roles are found for a resource (e.g. 'Owner' and 'Contributor')
+      --start-date string      Start date for the activation (as DD/MM/YYYY)
+  -s, --start-time string      Start time for the activation (as HH:MM)
   -T, --ticket-number string   Ticket number for the activation
       --ticket-system string   Ticket system for the activation
+  -v, --validate-only          Send the request to the validation endpoint of Azure PIM, without requesting the activation
 
 ```
 
@@ -243,18 +251,33 @@ $ az-pim-cli list resources
 
 # Activate the first matching role for a resource with the prefix 'S100'
 $ az-pim-cli activate resource --prefix S100
-2024/05/31 15:05:25 Activating role 'Contributor' for resource 'S100-Example-Subscription' with reason 'config' (ticket:  [])
-2024/05/31 15:05:34 The role 'Contributor' in 'S100-Example-Subscription' is now Provisioned
+time=2024-11-20T08:08:08.534+01:00 level=INFO msg="Requesting activation" role=Contributor scope=S100-Example-Subscription reason="" ticketNumber="" ticketSystem="" duration=480 startDateTime=""
+time=2024-11-20T08:08:20.129+01:00 level=INFO msg="The role assignment request was successful" status=Provisioned
+time=2024-11-20T08:08:20.129+01:00 level=INFO msg="Request completed" role=Contributor scope=S100-Example-Subscription status=Provisioned
 
 # Activate a specific role ('Owner') for a resource with the prefix 's100'
 $ az-pim-cli activate resource --prefix s100 --role owner
-2024/05/31 15:06:25 Activating role 'Owner' for resource 'S100-Example-Subscription' with reason 'config' (ticket:  [])
-2024/05/31 15:06:34 The role 'Owner' in 'S100-Example-Subscription' is now Provisioned
+time=2024-11-20T08:08:08.534+01:00 level=INFO msg="Requesting activation" role=Owner scope=S100-Example-Subscription reason="" ticketNumber="" ticketSystem="" duration=480 startDateTime=""
+time=2024-11-20T08:08:20.129+01:00 level=INFO msg="The role assignment request was successful" status=Provisioned
+time=2024-11-20T08:08:20.129+01:00 level=INFO msg="Request completed" role=Owner scope=S100-Example-Subscription status=Provisioned
 
 # Activate a resource role and specify a ticket number for the activation
 $ az-pim-cli activate resource --name S100-Example-Subscription --role Owner --ticket-system Jira --ticket-number T-1337
-2024/05/31 15:06:25 Activating role 'Owner' for resource 'S100-Example-Subscription' with reason 'config' (ticket: T-1337 [Jira])
-2024/05/31 15:06:34 The role 'Owner' in 'S100-Example-Subscription' is now Provisioned
+time=2024-11-20T08:08:08.534+01:00 level=INFO msg="Requesting activation" role=Owner scope=S100-Example-Subscription reason="" ticketNumber=T-1337 ticketSystem=Jira duration=480 startDateTime=""
+time=2024-11-20T08:08:20.129+01:00 level=INFO msg="The role assignment request was successful" status=Provisioned
+time=2024-11-20T08:08:20.129+01:00 level=INFO msg="Request completed" role=Owner scope=S100-Example-Subscription status=Provisioned
+
+# Activate a resource role and specify the start time for the activation. Uses the local timezone.
+$ az-pim-cli activate resource --name S100-Example-Subscription --role Owner --start-time 14:30
+time=2024-11-20T08:08:08.534+01:00 level=INFO msg="Requesting activation" role=Owner scope=S100-Example-Subscription reason="" ticketNumber=T-1337 ticketSystem=Jira duration=480 startDateTime=2024-11-20T14:30:00+01:00
+time=2024-11-20T08:08:20.129+01:00 level=INFO msg="The role assignment request was successful" status=Provisioned
+time=2024-11-20T08:08:20.129+01:00 level=INFO msg="Request completed" role=Owner scope=S100-Example-Subscription status=Provisioned
+
+# Activate a resource role and specify the start time and start date for the activation. Uses the local timezone.
+$ az-pim-cli activate resource --name S100-Example-Subscription --role Owner --start-date 31/12/2024 --start-time 09:30
+time=2024-11-20T08:08:08.534+01:00 level=INFO msg="Requesting activation" role=Owner scope=S100-Example-Subscription reason="" ticketNumber=T-1337 ticketSystem=Jira duration=480 startDateTime=2024-12-31T09:30:00+01:00
+time=2024-11-20T08:08:20.129+01:00 level=INFO msg="The role assignment request was successful" status=Provisioned
+time=2024-11-20T08:08:20.129+01:00 level=INFO msg="Request completed" role=Owner scope=S100-Example-Subscription status=Provisioned
 ```
 
 #### Groups
@@ -266,8 +289,9 @@ $ az-pim-cli list groups
 
 # Activate the first matching role for the group 'my-entra-id-group'
 $ az-pim-cli activate group --name my-entra-id-group --duration 5
-2024/05/31 15:00:10 Activating role 'Owner' for group 'my-entra-id-group' with reason 'config' (ticket:  [])
-2024/05/31 15:00:23 The role 'Owner' for group 'my-entra-id-group' is now Active
+time=2024-11-20T08:08:08.534+01:00 level=INFO msg="Requesting activation" role=Owner scope=my-entra-id-group reason="" ticketNumber="" ticketSystem="" duration=5 startDateTime=""
+time=2024-11-20T08:08:20.129+01:00 level=INFO msg="The role assignment request was successful" status=Provisioned subStatus=""
+time=2024-11-20T08:08:20.129+01:00 level=INFO msg="Request completed" role=Owner scope=my-entra-id-group status=Active
 ```
 
 #### Entra roles
@@ -279,8 +303,9 @@ $ az-pim-cli list roles
 
 # Activate the first matching role for the Entra role 'my-entra-id-role'
 $ az-pim-cli activate role --name my-entra-id-role --duration 5
-2024/05/31 15:00:10 Activating role 'Owner' for Entra role 'my-entra-id-role' with reason 'config' (ticket:  [])
-2024/05/31 15:00:23 The role 'Owner' for Entra role 'my-entra-id-role' is now Active
+time=2024-11-20T08:08:08.534+01:00 level=INFO msg="Requesting activation" role=Owner scope=my-entra-id-role reason="" ticketNumber="" ticketSystem="" duration=5 startDateTime=""
+time=2024-11-20T08:08:20.129+01:00 level=INFO msg="The role assignment request was successful" status=Provisioned subStatus=""
+time=2024-11-20T08:08:20.129+01:00 level=INFO msg="Request completed" role=Owner scope=my-entra-id-role status=Active
 ```
 
 ### Configuration options

--- a/cmd/activate.go
+++ b/cmd/activate.go
@@ -17,6 +17,8 @@ var name string
 var prefix string
 var roleName string
 var duration int
+var startDate string
+var startTime string
 var reason string
 var ticketSystem string
 var ticketNumber string
@@ -40,7 +42,7 @@ var activateResourceCmd = &cobra.Command{
 
 		eligibleResourceAssignments := pim.GetEligibleResourceAssignments(token, pim.AzureClient{})
 		resourceAssignment := utils.GetResourceAssignment(name, prefix, roleName, eligibleResourceAssignments)
-		scope, assignmentRequest := pim.CreateResourceAssignmentRequest(subjectId, resourceAssignment, duration, reason, ticketSystem, ticketNumber)
+		scope, assignmentRequest := pim.CreateResourceAssignmentRequest(subjectId, resourceAssignment, duration, startDate, startTime, reason, ticketSystem, ticketNumber)
 
 		slog.Info(
 			"Requesting activation",
@@ -49,6 +51,8 @@ var activateResourceCmd = &cobra.Command{
 			"reason", reason,
 			"ticketNumber", ticketNumber,
 			"ticketSystem", ticketSystem,
+			"duration", duration,
+			"startDateTime", assignmentRequest.Properties.ScheduleInfo.StartDateTime,
 		)
 
 		if dryRun {
@@ -81,7 +85,7 @@ func activateGovernanceRole(roleType string) {
 	subjectId := pim.GetUserInfo(pimGovernanceRoleToken).ObjectId
 	eligibleAssignments := pim.GetEligibleGovernanceRoleAssignments(roleType, subjectId, pimGovernanceRoleToken, pim.AzureClient{})
 	roleAssignment := utils.GetGovernanceRoleAssignment(name, prefix, roleName, eligibleAssignments)
-	roleType, assignmentRequest := pim.CreateGovernanceRoleAssignmentRequest(subjectId, roleType, roleAssignment, duration, reason, ticketSystem, ticketNumber)
+	roleType, assignmentRequest := pim.CreateGovernanceRoleAssignmentRequest(subjectId, roleType, roleAssignment, duration, startDate, startTime, reason, ticketSystem, ticketNumber)
 
 	slog.Info(
 		"Requesting activation",
@@ -90,6 +94,8 @@ func activateGovernanceRole(roleType string) {
 		"reason", reason,
 		"ticketNumber", ticketNumber,
 		"ticketSystem", ticketSystem,
+		"duration", duration,
+		"startDateTime", assignmentRequest.Schedule.StartDateTime,
 	)
 
 	if dryRun {
@@ -143,6 +149,8 @@ func init() {
 	activateCmd.PersistentFlags().StringVarP(&prefix, "prefix", "p", "", "The name prefix of the resource to activate (e.g. 'S399'). Alternative to 'name'.")
 	activateCmd.PersistentFlags().StringVarP(&roleName, "role", "r", "", "Specify the role to activate, if multiple roles are found for a resource (e.g. 'Owner' and 'Contributor')")
 	activateCmd.PersistentFlags().IntVarP(&duration, "duration", "d", pim.DEFAULT_DURATION_MINUTES, "Duration in minutes that the role should be activated for")
+	activateCmd.PersistentFlags().StringVar(&startDate, "start-date", "", "Start date for the activation (as DD/MM/YYYY)")
+	activateCmd.PersistentFlags().StringVarP(&startTime, "start-time", "s", "", "Start time for the activation (as HH:MM)")
 	activateCmd.PersistentFlags().StringVar(&reason, "reason", pim.DEFAULT_REASON, "Reason for the activation")
 	activateCmd.PersistentFlags().StringVar(&ticketSystem, "ticket-system", "", "Ticket system for the activation")
 	activateCmd.PersistentFlags().StringVarP(&ticketNumber, "ticket-number", "T", "", "Ticket number for the activation")

--- a/pkg/pim/client_test.go
+++ b/pkg/pim/client_test.go
@@ -122,7 +122,7 @@ func TestValidateResourceAssignmentRequest(t *testing.T) {
 	m := newMockClient()
 
 	resourceAssignment := &EligibleResourceAssignmentsDummyData.Value[0]
-	scope, resourceAssignmentRequest := CreateResourceAssignmentRequest(TEST_DUMMY_PRINCIPAL_ID, resourceAssignment, 30, "test", "Test", "1337")
+	scope, resourceAssignmentRequest := CreateResourceAssignmentRequest(TEST_DUMMY_PRINCIPAL_ID, resourceAssignment, 30, "", "", "test", "Test", "1337")
 
 	m.On("ValidateResourceAssignmentRequest", scope, resourceAssignmentRequest, TEST_DUMMY_JWT).Return(true)
 
@@ -142,7 +142,7 @@ func TestValidateGovernanceRoleAssignmentRequest(t *testing.T) {
 	m := newMockClient()
 
 	governanceRoleAssignment := &EligibleGovernanceRoleAssignmentsDummyData.Value[0]
-	roleType, governanceRoleAssignmentRequest := CreateGovernanceRoleAssignmentRequest(TEST_DUMMY_PRINCIPAL_ID, ROLE_TYPE_AAD_GROUPS, governanceRoleAssignment, 30, "test", "Test", "1337")
+	roleType, governanceRoleAssignmentRequest := CreateGovernanceRoleAssignmentRequest(TEST_DUMMY_PRINCIPAL_ID, ROLE_TYPE_AAD_GROUPS, governanceRoleAssignment, 30, "", "", "test", "Test", "1337")
 
 	m.On("ValidateGovernanceRoleAssignmentRequest", roleType, governanceRoleAssignmentRequest, TEST_DUMMY_JWT).Return(true)
 
@@ -162,7 +162,7 @@ func TestRequestResourceAssignment(t *testing.T) {
 	m := newMockClient()
 
 	resourceAssignment := &EligibleResourceAssignmentsDummyData.Value[0]
-	scope, resourceAssignmentRequest := CreateResourceAssignmentRequest(TEST_DUMMY_PRINCIPAL_ID, resourceAssignment, DEFAULT_DURATION_MINUTES, DEFAULT_REASON, "Test", "1337")
+	scope, resourceAssignmentRequest := CreateResourceAssignmentRequest(TEST_DUMMY_PRINCIPAL_ID, resourceAssignment, DEFAULT_DURATION_MINUTES, "", "", DEFAULT_REASON, "Test", "1337")
 	resourceAssignmentRequestResponse := &ResourceAssignmentRequestResponse{
 		Id:   resourceAssignment.Id,
 		Name: resourceAssignment.Name,
@@ -199,7 +199,7 @@ func TestRequestGovernanceRoleAssignmentAADGroup(t *testing.T) {
 	m := newMockClient()
 
 	governanceRoleAssignment := &EligibleGovernanceRoleAssignmentsDummyData.Value[0]
-	roleType, governanceRoleAssignmentRequest := CreateGovernanceRoleAssignmentRequest(TEST_DUMMY_PRINCIPAL_ID, ROLE_TYPE_AAD_GROUPS, governanceRoleAssignment, DEFAULT_DURATION_MINUTES, DEFAULT_REASON, "Test", "1337")
+	roleType, governanceRoleAssignmentRequest := CreateGovernanceRoleAssignmentRequest(TEST_DUMMY_PRINCIPAL_ID, ROLE_TYPE_AAD_GROUPS, governanceRoleAssignment, DEFAULT_DURATION_MINUTES, "", "", DEFAULT_REASON, "Test", "1337")
 	governanceRoleAssignmentRequestResponse := &GovernanceRoleAssignmentRequestResponse{
 		Id:               governanceRoleAssignment.Id,
 		ResourceId:       governanceRoleAssignmentRequest.ResourceId,

--- a/pkg/pim/utils.go
+++ b/pkg/pim/utils.go
@@ -161,7 +161,9 @@ func parseDateTime(dateStr string, timeStr string) (string, *common.Error) {
 		d = d.Add(time.Hour*time.Duration(t.Hour()) + time.Minute*time.Duration(t.Minute()))
 	}
 
-	formatted := d.Format(time.RFC3339)
+	// format is the same as 'time.RFC3339', except for the timezone part.
+	// must be customized due to inconsistencies in behavior when TZ environment variable is missing
+	formatted := d.Format("2006-01-02T15:04:05-07:00")
 	return formatted, nil
 }
 

--- a/pkg/pim/utils.go
+++ b/pkg/pim/utils.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/netr0m/az-pim-cli/pkg/common"
 )
@@ -107,7 +108,7 @@ func (response *GovernanceRoleAssignmentRequestResponse) CheckGovernanceRoleAssi
 		return false
 	}
 	if IsGovernanceRoleAssignmentRequestOK(response) {
-		slog.Info("The role assignment request was successfully validated", "status", response.Status.Status, "subStatus", response.Status.SubStatus)
+		slog.Info("The role assignment request was successful", "status", response.Status.Status, "subStatus", response.Status.SubStatus)
 		return true
 	}
 	if IsGovernanceRoleAssignmentRequestPending(response) {
@@ -118,7 +119,75 @@ func (response *GovernanceRoleAssignmentRequestResponse) CheckGovernanceRoleAssi
 	return false
 }
 
-func CreateResourceAssignmentRequest(subjectId string, resourceAssignment *ResourceAssignment, duration int, reason string, ticketSystem string, ticketNumber string) (string, *ResourceAssignmentRequestRequest) {
+func parseDate(dateStr string) (time.Time, error) {
+	dateLayout := "02/01/2006" // DD/MM/YYYY
+	d, err := time.Parse(dateLayout, dateStr)
+	if err != nil {
+		return d, err
+	}
+	return time.Date(d.Year(), d.Month(), d.Day(), 0, 0, 0, 0, time.Local), nil
+}
+
+func parseTime(timeStr string) (time.Time, error) {
+	timeLayout := "15:04" // HH:MM
+	return time.Parse(timeLayout, timeStr)
+}
+
+func parseDateTime(dateStr string, timeStr string) (string, *common.Error) {
+	_error := &common.Error{
+		Operation: "parseDateTime",
+	}
+	var d time.Time
+	if dateStr == "" {
+		// Get the current date, remove time info
+		now := time.Now().Local()
+		d = time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
+	} else {
+		_d, err := parseDate(dateStr)
+		if err != nil {
+			_error.Message = "Unable to parse the date"
+			_error.Err = err
+			return "", _error
+		}
+		d = _d
+	}
+	if timeStr != "" {
+		t, err := parseTime(timeStr)
+		if err != nil {
+			_error.Message = "Unable to parse the time"
+			_error.Err = err
+			return "", _error
+		}
+		d = d.Add(time.Hour*time.Duration(t.Hour()) + time.Minute*time.Duration(t.Minute()))
+	}
+
+	formatted := d.Format(time.RFC3339)
+	return formatted, nil
+}
+
+func CreateResourceAssignmentScheduleInfo(duration int, startDate string, startTime string) *ScheduleInfo {
+	var scheduleStart interface{}
+	if (startDate != "") || (startTime != "") {
+		startDateTime, err := parseDateTime(startDate, startTime)
+		if err != nil {
+			slog.Error(err.Error())
+			slog.Debug(err.Debug())
+			os.Exit(1)
+		}
+		scheduleStart = startDateTime
+	}
+
+	return &ScheduleInfo{
+		StartDateTime: scheduleStart,
+		Expiration: &ScheduleInfoExpiration{
+			Type:     "AfterDuration",
+			Duration: fmt.Sprintf("PT%dM", duration),
+		},
+	}
+}
+
+func CreateResourceAssignmentRequest(subjectId string, resourceAssignment *ResourceAssignment, duration int, startDate string, startTime string, reason string, ticketSystem string, ticketNumber string) (string, *ResourceAssignmentRequestRequest) {
+	scheduleInfo := CreateResourceAssignmentScheduleInfo(duration, startDate, startTime)
 	resourceAssignmentRequest := &ResourceAssignmentRequestRequest{
 		Properties: ResourceAssignmentRequestProperties{
 			PrincipalId:                     subjectId,
@@ -126,16 +195,10 @@ func CreateResourceAssignmentRequest(subjectId string, resourceAssignment *Resou
 			RequestType:                     "SelfActivate",
 			LinkedRoleEligibilityScheduleId: resourceAssignment.Properties.RoleEligibilityScheduleId,
 			Justification:                   reason,
-			ScheduleInfo: &ScheduleInfo{
-				StartDateTime: nil,
-				Expiration: &ScheduleInfoExpiration{
-					Type:     "AfterDuration",
-					Duration: fmt.Sprintf("PT%dM", duration),
-				},
-			},
-			TicketInfo:       &TicketInfo{TicketNumber: ticketNumber, TicketSystem: ticketSystem},
-			IsValidationOnly: false,
-			IsActivativation: true,
+			ScheduleInfo:                    scheduleInfo,
+			TicketInfo:                      &TicketInfo{TicketNumber: ticketNumber, TicketSystem: ticketSystem},
+			IsValidationOnly:                false,
+			IsActivativation:                true,
 		},
 	}
 	scope := resourceAssignment.Properties.ExpandedProperties.Scope.Id[1:]
@@ -143,7 +206,27 @@ func CreateResourceAssignmentRequest(subjectId string, resourceAssignment *Resou
 	return scope, resourceAssignmentRequest
 }
 
-func CreateGovernanceRoleAssignmentRequest(subjectId string, roleType string, governanceRoleAssignment *GovernanceRoleAssignment, duration int, reason string, ticketSystem string, ticketNumber string) (string, *GovernanceRoleAssignmentRequest) {
+func CreateGovernanceRoleAssignmentScheduleInfo(duration int, startDate string, startTime string) *GovernanceRoleAssignmentSchedule {
+	var scheduleStart interface{}
+	if (startDate != "") || (startTime != "") {
+		startDateTime, err := parseDateTime(startDate, startTime)
+		if err != nil {
+			slog.Error(err.Error())
+			slog.Debug(err.Debug())
+			os.Exit(1)
+		}
+		scheduleStart = startDateTime
+	}
+
+	return &GovernanceRoleAssignmentSchedule{
+		Type:          "Once",
+		StartDateTime: scheduleStart,
+		EndDateTime:   nil,
+		Duration:      fmt.Sprintf("PT%dM", duration),
+	}
+}
+
+func CreateGovernanceRoleAssignmentRequest(subjectId string, roleType string, governanceRoleAssignment *GovernanceRoleAssignment, duration int, startDate string, startTime string, reason string, ticketSystem string, ticketNumber string) (string, *GovernanceRoleAssignmentRequest) {
 	if !IsGovernanceRoleType(roleType) {
 		_error := common.Error{
 			Operation: "CreateGovernanceRoleAssignmentRequest",
@@ -153,21 +236,17 @@ func CreateGovernanceRoleAssignmentRequest(subjectId string, roleType string, go
 		os.Exit(1)
 	}
 
+	scheduleInfo := CreateGovernanceRoleAssignmentScheduleInfo(duration, startDate, startTime)
 	governanceRoleAssignmentRequest := &GovernanceRoleAssignmentRequest{
-		RoleDefinitionId: governanceRoleAssignment.RoleDefinitionId,
-		ResourceId:       governanceRoleAssignment.ResourceId,
-		SubjectId:        subjectId,
-		AssignmentState:  "Active",
-		Type:             "UserAdd",
-		Reason:           reason,
-		TicketNumber:     ticketNumber,
-		TicketSystem:     ticketSystem,
-		Schedule: &GovernanceRoleAssignmentSchedule{
-			Type:          "Once",
-			StartDateTime: nil,
-			EndDateTime:   nil,
-			Duration:      fmt.Sprintf("PT%dM", duration),
-		},
+		RoleDefinitionId:               governanceRoleAssignment.RoleDefinitionId,
+		ResourceId:                     governanceRoleAssignment.ResourceId,
+		SubjectId:                      subjectId,
+		AssignmentState:                "Active",
+		Type:                           "UserAdd",
+		Reason:                         reason,
+		TicketNumber:                   ticketNumber,
+		TicketSystem:                   ticketSystem,
+		Schedule:                       scheduleInfo,
 		LinkedEligibleRoleAssignmentId: governanceRoleAssignment.Id,
 		ScopedResourceId:               "",
 	}

--- a/pkg/pim/utils_test.go
+++ b/pkg/pim/utils_test.go
@@ -1,0 +1,27 @@
+/*
+Copyright © 2024 netr0m <netr0m@pm.me>
+*/
+package pim
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseDateTime(t *testing.T) {
+	now := time.Now().Local()
+	currentDate := now.Format("2006-01-02")
+	currentTZ := now.Format("-07:00")
+	errMsg := "resulting startDateTime does not match expected value"
+
+	dateOnly, _ := parseDateTime("31/12/2024", "")
+	timeOnly, _ := parseDateTime("", "13:37")
+	dateTime, _ := parseDateTime("31/12/2024", "13:37")
+
+	assert.Equal(t, fmt.Sprintf("2024-12-31T00:00:00%s", currentTZ), dateOnly, errMsg)
+	assert.Equal(t, fmt.Sprintf("%sT13:37:00%s", currentDate, currentTZ), timeOnly, errMsg)
+	assert.Equal(t, fmt.Sprintf("2024-12-31T13:37:00%s", currentTZ), dateTime, errMsg)
+}


### PR DESCRIPTION
# Description

Adds support for specifying the start time, i.e. to schedule activation.

- Resolves #80 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# Checklist:

- [x] I have read the [contribution guidelines](./../CONTRIBUTING.md)
- [x] My changes follow the [Styleguide](./../CONTRIBUTING.md#styleguides) of this project
- [x] I have run the [`pre-commit`](https://pre-commit.com/) hooks included in this repository
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] All GitHub Actions workflows for this branch/PR have run successfully
