### PR TITLE
Fix panic from JWT parsing

### DIFF
--- a/pkg/pim/client.go
+++ b/pkg/pim/client.go
@@ -86,7 +86,7 @@ func GetUserInfo(token string) AzureUserInfo {
 	// Parse claims
 	claims := decoded.Claims.(*AzureUserInfoClaims)
 
-	return *claims.AzureUserInfo
+	return claims.AzureUserInfo
 }
 
 func handleRequestErr(_error *common.Error, err error, req *http.Request) {

--- a/pkg/pim/models.go
+++ b/pkg/pim/models.go
@@ -11,8 +11,8 @@ type AzureUserInfo struct {
 }
 
 type AzureUserInfoClaims struct {
-	*jwt.MapClaims
-	*AzureUserInfo
+	jwt.MapClaims
+	AzureUserInfo
 }
 
 type PIMRequest struct {


### PR DESCRIPTION
# Description

Fixes a bug in JWT parsing. The documentation for `jwt.ParseWithClaims` [states](https://pkg.go.dev/github.com/golang-jwt/jwt/v5@v5.2.2#ParseWithClaims):

> Note: If you provide a custom claim implementation that embeds one of the standard claims (such as RegisteredClaims), make sure that a) you either embed a non-pointer version of the claims or b) if you are using a pointer, allocate the proper memory for it before passing in the overall claims, otherwise you might run into a panic.

We _do_ provide a custom claim implementation (`AzureUserInfoClaims`) that embeds one of the standard claims (`MapClaims`), but we were embedding a pointer version of the claim. The changes introduced in this PR help to avoid that panic by embedding a non-pointer version of the standard claim instead.

- Resolves https://github.com/netr0m/az-pim-cli/issues/83

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have read the [contribution guidelines](./../CONTRIBUTING.md)
- [x] My changes follow the [Styleguide](./../CONTRIBUTING.md#styleguides) of this project
- [x] I have run the [`pre-commit`](https://pre-commit.com/) hooks included in this repository
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] All GitHub Actions workflows for this branch/PR have run successfully
