### PR TITLE
build(goreleaser): include macos-universal binary in release archives

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -24,7 +24,7 @@ builds:
 
 universal_binaries:
   - id: macos-universal
-    replace: true
+    replace: false
     ids: [default]
     name_template: '{{ .ProjectName }}-{{ .Version }}-macos-universal'
 
@@ -44,7 +44,7 @@ archives:
       - LICENSE
       - README.md
       - CHANGELOG.md
-    ids: [default]
+    ids: [default, macos-universal]
   - id: binaries
     formats: [binary]
     name_template: >-
@@ -52,7 +52,7 @@ archives:
       {{- if eq .Os "darwin" -}}macos{{- else -}}{{ .Os }}{{- end -}}-
       {{- if eq .Arch "amd64" -}}x86_64{{- else -}}{{ .Arch }}{{- end -}}
       {{- if .Arm }}v{{ .Arm }}{{ end }}
-    ids: [default]
+    ids: [default, macos-universal]
 
 checksum:
   name_template: '{{ .ProjectName }}-{{ .Version }}-checksums.txt'


### PR DESCRIPTION
# Description

Include macos binaries, which were excluded due to changes in the goreleaser config.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have read the [contribution guidelines](./../CONTRIBUTING.md)
- [x] My changes follow the [Styleguide](./../CONTRIBUTING.md#styleguides) of this project
- [x] I have run the [`pre-commit`](https://pre-commit.com/) hooks included in this repository
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] All GitHub Actions workflows for this branch/PR have run successfully
