### PR TITLE
fix: use right scope to generate pim token for groups and roles

### DIFF
--- a/cmd/activate.go
+++ b/cmd/activate.go
@@ -83,7 +83,7 @@ func activateGovernanceRole(roleType string) {
 		slog.Error("Invalid role type specified.")
 		os.Exit(1)
 	}
-	token := pim.GetAccessToken(AzureClientInstance.ARMBaseURL, AzureClientInstance)
+	token := pim.GetAccessToken(AzureClientInstance.ASMScope, AzureClientInstance)
 	subjectId := pim.GetUserInfo(token).ObjectId
 
 	eligibleAssignments := pim.GetEligibleGovernanceRoleAssignments(roleType, subjectId, token, AzureClientInstance)


### PR DESCRIPTION
# Description

Problem discussed: https://github.com/netr0m/az-pim-cli/pull/113

- Resolves #116 

Wrong endpoint is used to generate the pim token for groups and roles.