### PR TITLE
feat(activate): add support for activation at a narrower scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,33 +136,39 @@ $ az-pim-cli activate resource
 ```bash
 # Activate the first matching role for a resource with the prefix 'S100'
 $ az-pim-cli activate resource --prefix S100
-time=2024-11-20T08:08:08.534+01:00 level=INFO msg="Requesting activation" role=Contributor scope=S100-Example-Subscription reason="" ticketNumber="" ticketSystem="" duration=480 startDateTime=""
+time=2024-11-20T08:08:08.534+01:00 level=INFO msg="Requesting activation" role=Contributor scope=/subscriptions/6d80fbe7-7508-46e8-9fbf-a9d2e0dfec83 reason="" ticketNumber="" ticketSystem="" duration=480 startDateTime=""
 time=2024-11-20T08:08:20.129+01:00 level=INFO msg="The role assignment request was successful" status=Provisioned
-time=2024-11-20T08:08:20.129+01:00 level=INFO msg="Request completed" role=Contributor scope=S100-Example-Subscription status=Provisioned
+time=2024-11-20T08:08:20.129+01:00 level=INFO msg="Request completed" role=Contributor scope=/subscriptions/6d80fbe7-7508-46e8-9fbf-a9d2e0dfec83 status=Provisioned
 
 # Activate a specific role ('Owner') for a resource with the prefix 's100'
 $ az-pim-cli activate resource --prefix s100 --role owner
-time=2024-11-20T08:08:08.534+01:00 level=INFO msg="Requesting activation" role=Owner scope=S100-Example-Subscription reason="" ticketNumber="" ticketSystem="" duration=480 startDateTime=""
+time=2024-11-20T08:08:08.534+01:00 level=INFO msg="Requesting activation" role=Owner scope=/subscriptions/6d80fbe7-7508-46e8-9fbf-a9d2e0dfec83 reason="" ticketNumber="" ticketSystem="" duration=480 startDateTime=""
 time=2024-11-20T08:08:20.129+01:00 level=INFO msg="The role assignment request was successful" status=Provisioned
-time=2024-11-20T08:08:20.129+01:00 level=INFO msg="Request completed" role=Owner scope=S100-Example-Subscription status=Provisioned
+time=2024-11-20T08:08:20.129+01:00 level=INFO msg="Request completed" role=Owner scope=/subscriptions/6d80fbe7-7508-46e8-9fbf-a9d2e0dfec83 status=Provisioned
+
+# Activate a specific role ('Owner') for a resource with a narrower scope
+$ az-pim-cli activate resource --name S100-Example-Subscription --scope /subscriptions/6d80fbe7-7508-46e8-9fbf-a9d2e0dfec83/resourceGroups/example-rg --role Owner
+time=2024-11-20T08:08:08.534+01:00 level=INFO msg="Requesting activation" role=Owner scope=/subscriptions/6d80fbe7-7508-46e8-9fbf-a9d2e0dfec83/resourceGroups/example-rg reason="" ticketNumber="" ticketSystem="" duration=480 startDateTime=""
+time=2024-11-20T08:08:20.129+01:00 level=INFO msg="The role assignment request was successful" status=Provisioned
+time=2024-11-20T08:08:20.129+01:00 level=INFO msg="Request completed" role=Owner scope=/subscriptions/6d80fbe7-7508-46e8-9fbf-a9d2e0dfec83/resourceGroups/example-rg status=Provisioned
 
 # Activate a resource role and specify a ticket number for the activation
 $ az-pim-cli activate resource --name S100-Example-Subscription --role Owner --ticket-system Jira --ticket-number T-1337
-time=2024-11-20T08:08:08.534+01:00 level=INFO msg="Requesting activation" role=Owner scope=S100-Example-Subscription reason="" ticketNumber=T-1337 ticketSystem=Jira duration=480 startDateTime=""
+time=2024-11-20T08:08:08.534+01:00 level=INFO msg="Requesting activation" role=Owner scope=/subscriptions/6d80fbe7-7508-46e8-9fbf-a9d2e0dfec83 reason="" ticketNumber=T-1337 ticketSystem=Jira duration=480 startDateTime=""
 time=2024-11-20T08:08:20.129+01:00 level=INFO msg="The role assignment request was successful" status=Provisioned
-time=2024-11-20T08:08:20.129+01:00 level=INFO msg="Request completed" role=Owner scope=S100-Example-Subscription status=Provisioned
+time=2024-11-20T08:08:20.129+01:00 level=INFO msg="Request completed" role=Owner scope=/subscriptions/6d80fbe7-7508-46e8-9fbf-a9d2e0dfec83 status=Provisioned
 
 # Activate a resource role and specify the start time for the activation. Uses the local timezone.
 $ az-pim-cli activate resource --name S100-Example-Subscription --role Owner --start-time 14:30
-time=2024-11-20T08:08:08.534+01:00 level=INFO msg="Requesting activation" role=Owner scope=S100-Example-Subscription reason="" ticketNumber=T-1337 ticketSystem=Jira duration=480 startDateTime=2024-11-20T14:30:00+01:00
+time=2024-11-20T08:08:08.534+01:00 level=INFO msg="Requesting activation" role=Owner scope=/subscriptions/6d80fbe7-7508-46e8-9fbf-a9d2e0dfec83 reason="" ticketNumber=T-1337 ticketSystem=Jira duration=480 startDateTime=2024-11-20T14:30:00+01:00
 time=2024-11-20T08:08:20.129+01:00 level=INFO msg="The role assignment request was successful" status=Provisioned
-time=2024-11-20T08:08:20.129+01:00 level=INFO msg="Request completed" role=Owner scope=S100-Example-Subscription status=Provisioned
+time=2024-11-20T08:08:20.129+01:00 level=INFO msg="Request completed" role=Owner scope=/subscriptions/6d80fbe7-7508-46e8-9fbf-a9d2e0dfec83 status=Provisioned
 
 # Activate a resource role and specify the start time and start date for the activation. Uses the local timezone.
 $ az-pim-cli activate resource --name S100-Example-Subscription --role Owner --start-date 31/12/2024 --start-time 09:30
-time=2024-11-20T08:08:08.534+01:00 level=INFO msg="Requesting activation" role=Owner scope=S100-Example-Subscription reason="" ticketNumber=T-1337 ticketSystem=Jira duration=480 startDateTime=2024-12-31T09:30:00+01:00
+time=2024-11-20T08:08:08.534+01:00 level=INFO msg="Requesting activation" role=Owner scope=/subscriptions/6d80fbe7-7508-46e8-9fbf-a9d2e0dfec83 reason="" ticketNumber=T-1337 ticketSystem=Jira duration=480 startDateTime=2024-12-31T09:30:00+01:00
 time=2024-11-20T08:08:20.129+01:00 level=INFO msg="The role assignment request was successful" status=Provisioned
-time=2024-11-20T08:08:20.129+01:00 level=INFO msg="Request completed" role=Owner scope=S100-Example-Subscription status=Provisioned
+time=2024-11-20T08:08:20.129+01:00 level=INFO msg="Request completed" role=Owner scope=/subscriptions/6d80fbe7-7508-46e8-9fbf-a9d2e0dfec83 status=Provisioned
 ```
 
 </details>

--- a/cmd/activate.go
+++ b/cmd/activate.go
@@ -24,6 +24,7 @@ var ticketSystem string
 var ticketNumber string
 var dryRun bool
 var validateOnly bool
+var resourceScope string
 
 var activateCmd = &cobra.Command{
 	Use:     "activate",
@@ -42,12 +43,12 @@ var activateResourceCmd = &cobra.Command{
 
 		eligibleResourceAssignments := pim.GetEligibleResourceAssignments(token, AzureClientInstance)
 		resourceAssignment := utils.GetResourceAssignment(name, prefix, roleName, eligibleResourceAssignments)
-		scope, assignmentRequest := pim.CreateResourceAssignmentRequest(subjectId, resourceAssignment, duration, startDate, startTime, reason, ticketSystem, ticketNumber)
+		scope, assignmentRequest := pim.CreateResourceAssignmentRequestWithScope(subjectId, resourceAssignment, resourceScope, duration, startDate, startTime, reason, ticketSystem, ticketNumber)
 
 		slog.Info(
 			"Requesting activation",
 			"role", resourceAssignment.Properties.ExpandedProperties.RoleDefinition.DisplayName,
-			"scope", resourceAssignment.Properties.ExpandedProperties.Scope.DisplayName,
+			"scope", scope,
 			"reason", reason,
 			"ticketNumber", ticketNumber,
 			"ticketSystem", ticketSystem,
@@ -72,7 +73,7 @@ var activateResourceCmd = &cobra.Command{
 		slog.Info(
 			"Request completed",
 			"role", resourceAssignment.Properties.ExpandedProperties.RoleDefinition.DisplayName,
-			"scope", resourceAssignment.Properties.ExpandedProperties.Scope.DisplayName,
+			"scope", scope,
 			"status", requestResponse.Properties.Status,
 		)
 	},
@@ -163,4 +164,6 @@ func init() {
 
 	activateCmd.MarkFlagsOneRequired("name", "prefix")
 	activateCmd.MarkFlagsMutuallyExclusive("name", "prefix")
+
+	activateResourceCmd.Flags().StringVar(&resourceScope, "scope", "", "The scope to activate the resource role at, if different from the eligible assignment scope")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -97,6 +97,7 @@ func initConfig() {
 	bindFlags(activateCmd, vpr)
 	bindFlags(listGroupCmd, vpr)
 	bindFlags(listEntraRoleCmd, vpr)
+	bindFlags(activateResourceCmd, vpr)
 	bindFlags(activateGroupCmd, vpr)
 	bindFlags(activateEntraRoleCmd, vpr)
 

--- a/pkg/pim/client.go
+++ b/pkg/pim/client.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"os"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
@@ -246,6 +247,17 @@ func GetEligibleGovernanceRoleAssignments(roleType string, subjectId string, tok
 }
 
 func (c AzureClient) ValidateResourceAssignmentRequest(scope string, resourceAssignmentRequest *ResourceAssignmentRequestRequest, token string) bool {
+	u, err := url.JoinPath(c.ARMBaseURL, scope, ARM_BASE_PATH, "roleAssignmentScheduleRequests", uuid.NewString(), "validate")
+	if err != nil {
+		_error := common.Error{
+			Operation: "ValidateResourceAssignmentRequest",
+			Message:   err.Error(),
+			Err:       err,
+		}
+		slog.Error(_error.Error())
+		os.Exit(1)
+	}
+
 	params := map[string]string{
 		"api-version": AZ_PIM_API_VERSION,
 	}
@@ -255,13 +267,7 @@ func (c AzureClient) ValidateResourceAssignmentRequest(scope string, resourceAss
 
 	validationResponse := &ResourceAssignmentRequestResponse{}
 	_ = Request(&PIMRequest{
-		Url: fmt.Sprintf(
-			"%s/%s/%s/roleAssignmentScheduleRequests/%s/validate",
-			c.ARMBaseURL,
-			scope,
-			ARM_BASE_PATH,
-			uuid.NewString(),
-		),
+		Url:     u,
 		Token:   token,
 		Method:  "POST",
 		Params:  params,
@@ -299,19 +305,24 @@ func ValidateGovernanceRoleAssignmentRequest(roleType string, roleAssignmentRequ
 }
 
 func (c AzureClient) RequestResourceAssignment(scope string, resourceAssignmentRequest *ResourceAssignmentRequestRequest, token string) *ResourceAssignmentRequestResponse {
+	u, err := url.JoinPath(c.ARMBaseURL, scope, ARM_BASE_PATH, "roleAssignmentScheduleRequests", uuid.NewString())
+	if err != nil {
+		_error := common.Error{
+			Operation: "RequestResourceAssignment",
+			Message:   err.Error(),
+			Err:       err,
+		}
+		slog.Error(_error.Error())
+		os.Exit(1)
+	}
+
 	params := map[string]string{
 		"api-version": AZ_PIM_API_VERSION,
 	}
 
 	responseModel := &ResourceAssignmentRequestResponse{}
 	_ = Request(&PIMRequest{
-		Url: fmt.Sprintf(
-			"%s/%s/%s/roleAssignmentScheduleRequests/%s",
-			c.ARMBaseURL,
-			scope,
-			ARM_BASE_PATH,
-			uuid.NewString(),
-		),
+		Url:     u,
 		Token:   token,
 		Method:  "PUT",
 		Params:  params,

--- a/pkg/pim/utils.go
+++ b/pkg/pim/utils.go
@@ -189,6 +189,10 @@ func CreateResourceAssignmentScheduleInfo(duration int, startDate string, startT
 }
 
 func CreateResourceAssignmentRequest(subjectId string, resourceAssignment *ResourceAssignment, duration int, startDate string, startTime string, reason string, ticketSystem string, ticketNumber string) (string, *ResourceAssignmentRequestRequest) {
+	return CreateResourceAssignmentRequestWithScope(subjectId, resourceAssignment, "", duration, startDate, startTime, reason, ticketSystem, ticketNumber)
+}
+
+func CreateResourceAssignmentRequestWithScope(subjectId string, resourceAssignment *ResourceAssignment, scope string, duration int, startDate string, startTime string, reason string, ticketSystem string, ticketNumber string) (string, *ResourceAssignmentRequestRequest) {
 	scheduleInfo := CreateResourceAssignmentScheduleInfo(duration, startDate, startTime)
 	resourceAssignmentRequest := &ResourceAssignmentRequestRequest{
 		Properties: ResourceAssignmentRequestProperties{
@@ -203,7 +207,9 @@ func CreateResourceAssignmentRequest(subjectId string, resourceAssignment *Resou
 			IsActivativation:                true,
 		},
 	}
-	scope := resourceAssignment.Properties.ExpandedProperties.Scope.Id[1:]
+	if scope == "" {
+		scope = resourceAssignment.Properties.ExpandedProperties.Scope.Id
+	}
 
 	return scope, resourceAssignmentRequest
 }

--- a/pkg/pim/utils_test.go
+++ b/pkg/pim/utils_test.go
@@ -25,3 +25,31 @@ func TestParseDateTime(t *testing.T) {
 	assert.Equal(t, fmt.Sprintf("%sT13:37:00%s", currentDate, currentTZ), timeOnly, errMsg)
 	assert.Equal(t, fmt.Sprintf("2024-12-31T13:37:00%s", currentTZ), dateTime, errMsg)
 }
+
+func TestCreateResourceAssignmentRequest(t *testing.T) {
+	resourceAssignment := &EligibleResourceAssignmentsDummyData.Value[0]
+	tests := []struct {
+		name     string
+		scope    string
+		expected string
+	}{
+		{
+			name:     "without resource scope",
+			scope:    "",
+			expected: resourceAssignment.Properties.ExpandedProperties.Scope.Id,
+		},
+		{
+			name:     "with resource scope",
+			scope:    fmt.Sprintf("/subscriptions/%s/resourceGroups/rg", TEST_DUMMY_SUBSCRIPTION_1_ID),
+			expected: fmt.Sprintf("/subscriptions/%s/resourceGroups/rg", TEST_DUMMY_SUBSCRIPTION_1_ID),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scope, _ := CreateResourceAssignmentRequestWithScope(TEST_DUMMY_PRINCIPAL_ID, resourceAssignment, tt.scope, 30, "", "", "test", "Test", "1337")
+
+			assert.Equal(t, tt.expected, scope)
+		})
+	}
+}


### PR DESCRIPTION
# Description

This PR adds support for activating a role at a scope that is narrower than the eligible role assignment scope.

For example, if a user has an eligible role assignment at the subscription scope, they can activate the role for a specific resource or resource group within that subscription.

The Azure portal supports the same behavior for directly contained in a resource group (for example, a Storage Account or Key Vault), although it does not support narrower child-resource scopes such as blob containers.

<img width="574" height="579" alt="image" src="https://github.com/user-attachments/assets/705b82b3-68f2-49f8-96ed-c2a590fa88b6" />


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# Checklist:

- [x] I have read the [contribution guidelines](./../CONTRIBUTING.md)
- [x] My changes follow the [Styleguide](./../CONTRIBUTING.md#styleguides) of this project
- [x] I have run the [`pre-commit`](https://pre-commit.com/) hooks included in this repository
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] All GitHub Actions workflows for this branch/PR have run successfully
