### PR TITLE
fix(list): show help when no subcommand is provided

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -13,7 +13,6 @@ var listCmd = &cobra.Command{
 	Use:     "list",
 	Aliases: []string{"l", "ls"},
 	Short:   "Query Azure PIM for eligible role assignments",
-	Run:     func(cmd *cobra.Command, args []string) {},
 }
 
 var listResourceCmd = &cobra.Command{


### PR DESCRIPTION
# Description

Running `az-pim-cli list` without a subcommand currently produces no output, which can be confusing for users because it is not obvious that a subcommand is required.

This PR changes the behavior to display the command help when no subcommand is specified, making the command more user-friendly and improving discoverability of the available subcommands.

Before:

```console
$ go run . list
```

After:

```console
$ go run . list
Query Azure PIM for eligible role assignments

Usage:
  az-pim-cli list [flags]
  az-pim-cli list [command]

Aliases:
  list, l, ls

Available Commands:
  group       Query Azure PIM for eligible group assignments
  resource    Query Azure PIM for eligible resource assignments (azure resources)
  role        Query Azure PIM for eligible Entra role assignments

Flags:
  -h, --help   help for list

Global Flags:
      --cloud string    Which Azure environment to use ('global', 'usgov', 'china') (default "global")
  -c, --config string   config file (default is $HOME/.az-pim-cli.yaml)
      --debug           Enable debug logging

Use "az-pim-cli list [command] --help" for more information about a command.
```

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have read the [contribution guidelines](./../CONTRIBUTING.md)
- [x] My changes follow the [Styleguide](./../CONTRIBUTING.md#styleguides) of this project
- [x] I have run the [`pre-commit`](https://pre-commit.com/) hooks included in this repository
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] All GitHub Actions workflows for this branch/PR have run successfully
